### PR TITLE
Fix memory leaks and instance of UB

### DIFF
--- a/main.c
+++ b/main.c
@@ -133,6 +133,7 @@ int main() {
   color_mandelbrot_pixmap(&pixmap, COLOR_K, iterates);
   unsigned int write_png_status = write_png_from_pixmap(&pixmap, "mandel.png");
   
+  free(pixmap.pixels);
   if (write_png_status != 0) return -1;
   return 0;
 }

--- a/writepng.c
+++ b/writepng.c
@@ -65,7 +65,7 @@ int write_png_from_pixmap(pixmap_t * pixmap, const char * path) {
   png_set_rows(png, info, row_pointers);
   png_write_png(png, info, PNG_TRANSFORM_IDENTITY, NULL);
 
-  for (unsigned int y; y < pixmap->height; y++) {
+  for (unsigned int y = 0; y < pixmap->height; y++) {
     free(row_pointers[y]);
   }
   free(row_pointers);


### PR DESCRIPTION
In main.c on line 117 the call
```c
pixmap.pixels = calloc(IMG_WIDTH * IMG_HEIGHT, sizeof(pixel_t)); 
```
was allocating a slice of memory that was never freed. Technically this doesn't really matter since the OS will (almost always) clean up leaked memory anyway, but it *did* seem like you were trying to clean up resources in writepng.c.

In writepng.c on line 68 there was a loop that was intended to free the png rows, but the loop variable `y` was never initialized, resulting in undefined behavior which (on my machine) meaning that the rows would never be freed.
An initializer of zero was added for this loop variable.

This issues were discovered by adding (and compiling with) the flags `-pedantic -Wall -Wextra -fsanitize=leak` using clang-6.0.